### PR TITLE
More consistent use of db_query with replacements and helper functions.

### DIFF
--- a/sites/all/modules/custom/aicapp/aicapp.module
+++ b/sites/all/modules/custom/aicapp/aicapp.module
@@ -425,13 +425,13 @@ function aicapp_objectGalleryStatus_submit($form, &$form_state) {
           SET field_gallery_location_value = :gal
           WHERE entity_id = :nid
           AND entity_type = 'node'
-          AND bundle = :type", array(':type' => AICAPP_TYPE_OBJECT, ':nid' => $object->nid, ':gal' => $loc));
+          AND bundle = :bundle", array(':bundle' => AICAPP_TYPE_OBJECT, ':nid' => $object->nid, ':gal' => $loc));
 
       db_query("UPDATE {field_revision_field_gallery_location}
           SET field_gallery_location_value = :gal
           WHERE entity_id = :nid
           AND entity_type = 'node'
-          AND bundle = :type", array(':type' => AICAPP_TYPE_OBJECT, ':nid' => $object->nid, ':gal' => $loc));
+          AND bundle = :bundle", array(':bundle' => AICAPP_TYPE_OBJECT, ':nid' => $object->nid, ':gal' => $loc));
 
       // Setting node to unpublished.
       db_query("UPDATE {node} SET status = 0 WHERE nid = :nid", array(':nid' => $object->nid));
@@ -463,16 +463,17 @@ function aicapp_objectGalleryStatus_submit($form, &$form_state) {
  * verify that the gallery assigned to a published object is one of the galleries we have in Drupal.
  */
 function aicapp_verify_obj_gallery_submit($form, &$form_state) {
-  $objects = db_query("SELECT node.nid, fi.field_object_id_value AS object_id
+  $object_query = "SELECT node.nid, fi.field_object_id_value AS object_id
       FROM {node}, {field_data_field_object_id} fi
       WHERE node.nid = fi.entity_id
-      AND fi.bundle = AICAPP_TYPE_OBJECT
-      AND node.status = 1");
-
-  $galleries = db_query("SELECT nid, title
+      AND fi.bundle = :bundle
+      AND node.status = 1";
+  $objects = db_query($object_query, array(':bundle' => AICAPP_TYPE_OBJECT));
+  $gallery_query = "SELECT nid, title
       FROM {node}
-      WHERE node.type = AICAPP_TYPE_GALLERY
-      AND node.status = 1");
+      WHERE node.type = :bundle
+      AND node.status = 1";
+  $galleries = db_query($gallery_query, array(':bundle' => AICAPP_TYPE_GALLERY));
 
   // need a simple array
   $gals = array();
@@ -514,11 +515,11 @@ function _email_art_removed($art_gone) {
   // Now collect all objects from our Drupal DB (field_in_gallery table) that are in gallery and are published
   $result = db_query("SELECT f.entity_id, f.field_in_gallery_value
     FROM {field_data_field_in_gallery} f, {node} n
-    WHERE f.bundle = AICAPP_TYPE_OBJECT
+    WHERE f.bundle = :bundle
     AND f.entity_type = 'node'
     AND f.field_in_gallery_value = 1
     AND f.entity_id = n.nid
-    AND n.status = 1");
+    AND n.status = 1", array(':bundle' => AICAPP_TYPE_OBJECT));
 
   $was_in_gallery = array();
   // grab the ones that have been on display
@@ -538,17 +539,26 @@ function _email_art_removed($art_gone) {
     $object_list = '';
     foreach ($recent_pulled as $nid) {
       $object = node_load($nid);
-
       // was this object on a tour?
+      // V1 version of finding if a object is on a tour.
       $result = db_query("SELECT entity_id FROM field_data_field_stops2 WHERE field_stops2_value = :d", array(':d' => $nid));
       $tours = array();
       foreach ($result as $item) {
         $tours[] = node_load($item->entity_id);
       }
+      // Try V2 tour stops if $tours is empty.
+      if (empty($tours)) {
+        if ($tour_objects = _aicapp_get_tour_objects(array(), $nid)) {
+          foreach ($tour_objects as $tour_nid => $tour_values) {
+            $tours[] = node_load($tour_nid);
+          }
+        }
+      }
+
       $object_list .= '<li>object_id = ' . $object->object_id . ' -- ' . $object->title_t;
       if (!empty($tours[0])) {
         foreach ($tours as $tour) {
-          $object_list .= '<br>-- On tour: ' . $tour->title;
+          $object_list .= '<br>-- On tour: ' . check_plain($tour->title);
         }
       }
       $object_list .= '</li>';
@@ -567,6 +577,82 @@ function _email_art_removed($art_gone) {
       drupal_set_message('Email notice unable to send. (These objects were removed):<ul>' . $object_list . '</ul>', 'error');
     }
   }
+}
+
+/**
+ * Helper function that lists, given a list of tour ids, will return all objects
+ * that are currently in a published  tour, grouped by tour. You can also pass an array of
+ * object ids to limit the items returned to only those objects. Passing an
+ * array with just one object id will return all the tours that object is in.
+ *
+ */
+function _aicapp_get_tour_objects($tour_nids = array(), $object_nids = array()) {
+  // Normalize arguments to make sure we have arrays.
+  if (!is_array($tour_nids)) {
+    $tour_nids = is_numeric($tour_nids) ? array($tour_nids) : array();
+  }
+  if (!is_array($object_nids)) {
+    $object_nids = is_numeric($object_nids) ? array($object_nids) : array();
+  }
+  // Load all tours filted by the given tour ids.
+  $query = new EntityFieldQuery();
+  $query
+    ->entityCondition('entity_type', 'node')
+    ->propertyCondition('type', AICAPP_TYPE_TOUR, '=')
+    ->propertyCondition('status', 1, '=');
+  if (count($tour_nids)) {
+    $query->entityCondition('entity_id', $tour_nids, 'IN');
+  }
+  $results = $query->execute();
+  $tours = isset($results['node']) ? entity_load('node', array_keys($results['node'])) : array();
+  $tour_objects = array();
+  foreach ($tours as $tour) {
+    $tour_objects[$tour->nid] = array();
+    $stops = _aicapp_get_tour_stops($tour);
+    foreach ($stops as $delta => $stop) {
+      if (!isset($stop['object']) || (count($object_nids) && !in_array($stop['object'], $object_nids))) {
+        continue;
+      }
+      $tour_objects[$tour->nid][$stop['object']] = $stop;
+    }
+  }
+  return array_filter($tour_objects);
+}
+
+function _aicapp_get_tour_stops($tour) {
+  $stops = array();
+  if (empty($tour->nid)) {
+    return $stops;
+  }
+  if ($fc_items = field_get_items('node', $tour, 'field_tour_stops')) {
+    $i = 0;
+    foreach ($fc_items as $fc_item) {
+      $item = field_collection_field_get_entity($fc_item);
+      $audio_commentary_id = !empty($item->field_tour_stop_audio_commentary) ? $item->field_tour_stop_audio_commentary[LANGUAGE_NONE][0]['target_id'] : NULL;
+      $audio_commentary = $audio_commentary_id ? entity_load_single('field_collection_item', $audio_commentary_id) : NULL;
+      $audio_node_id = !empty($audio_commentary->field_audio_commentary_audio) ? $audio_commentary->field_audio_commentary_audio[LANGUAGE_NONE][0]['target_id']: NULL;
+      $bumper_commentary_id = !empty($item->field_tour_stop_audio_bumper) ? $item->field_tour_stop_audio_bumper[LANGUAGE_NONE][0]['target_id'] : NULL;
+      $bumper_commentary = $bumper_commentary_id ? entity_load_single('field_collection_item', $bumper_commentary_id) : NULL;
+      $bumper_node_id = is_object($bumper_commentary) ? $bumper_commentary->hostEntityId() : NULL;
+      $object_node_id = !empty($item->field_tour_stop_object) ? $item->field_tour_stop_object[LANGUAGE_NONE][0]['target_id'] : NULL;
+      // if ($object_node = node_load($object_node_id)) {
+      //   $entity = entity_metadata_wrapper('node', $object_node_id);
+      //   $object_id = $entity->field_object_id->value();
+      // }
+      // else {
+      //   $object_id = NULL;
+      // }
+      $stops[] = array(
+        //'object_id' => $object_id,
+        'object' => $object_node_id,
+        'audio_id' => $audio_node_id,
+        'audio_bumper' => $bumper_node_id,
+        'sort' => $i,
+      );
+      $i++;
+    }
+  }
+  return $stops;
 }
 
 /**
@@ -839,7 +925,7 @@ function aicapp_gendata_form_submit($form, &$form_state) {
 }
 
 /**
- * Collect tour stops and return as a group.
+ * Collect tour stops and return as a group. Use for V1 App JSON.
  */
 function aicapp_collect_tour_stops($stops = array()) {
   $full_stops = $audio = $objects = array();
@@ -1310,26 +1396,7 @@ function strip_drupal_from_node(&$node) {
   }
   // Tour stops.
   if (isset($node->field_tour_stops)) {
-    $node->tour_stop_items = array();
-    if ($fc_items = field_get_items('node', $node, 'field_tour_stops')) {
-      $i = 0;
-      foreach ($fc_items as $fc_item) {
-        $item = field_collection_field_get_entity($fc_item);
-        $audio_commentary_id = !empty($item->field_tour_stop_audio_commentary) ? $item->field_tour_stop_audio_commentary[LANGUAGE_NONE][0]['target_id'] : NULL;
-        $audio_commentary = $audio_commentary_id ? entity_load_single('field_collection_item', $audio_commentary_id) : NULL;
-        $audio_node_id = !empty($audio_commentary->field_audio_commentary_audio) ? $audio_commentary->field_audio_commentary_audio[LANGUAGE_NONE][0]['target_id']: NULL;
-        $bumper_commentary_id = !empty($item->field_tour_stop_audio_bumper) ? $item->field_tour_stop_audio_bumper[LANGUAGE_NONE][0]['target_id'] : NULL;
-        $bumper_commentary = $bumper_commentary_id ? entity_load_single('field_collection_item', $bumper_commentary_id) : NULL;
-        $bumper_node_id = is_object($bumper_commentary) ? $bumper_commentary->hostEntityId() : NULL;
-        $node->tour_stop_items[] = array(
-          'object' => !empty($item->field_tour_stop_object) ? $item->field_tour_stop_object[LANGUAGE_NONE][0]['target_id'] : NULL,
-          'audio_id' => $audio_node_id,
-          'audio_bumper' => $bumper_node_id,
-          'sort' => $i,
-        );
-        $i++;
-      }
-    }
+    $node->tour_stop_items = _aicapp_get_tour_stops($node);
   }
   // Tour Duration.
   if (isset($node->field_tour_duration)) {
@@ -1612,17 +1679,17 @@ function aicappSaveNode($object, $type) {
       $node->field_floor[$node->language][0]['value'] = $object['floor'];
       // Set the floor reference field.
       // First find the entity to reference.
-      $efq = new EntityFieldQuery();
-      $efq->entityCondition('entity_type', 'field_collection_item');
-      $efq->propertyCondition('field_name', 'field_floor_map');
+      $query = new EntityFieldQuery();
+      $query->entityCondition('entity_type', 'field_collection_item');
+      $query->propertyCondition('field_name', 'field_floor_map');
       // Sometimes Level 0 is known as LL.
       $floors = array($object['floor']);
       if (strtolower($object['floor']) === 'll') {
         $floors[] = 0;
       }
-      $efq->fieldCondition('field_floor_label', 'value', $floors, 'IN');
-      $efq->range(0, 1);
-      $result = $efq->execute();
+      $query->fieldCondition('field_floor_label', 'value', $floors, 'IN');
+      $query->range(0, 1);
+      $result = $query->execute();
       if (!empty($result['field_collection_item'])) {
         $floor_reference = key($result['field_collection_item']);
         $node->field_floor_reference[$node->language][0]['target_id'] = $floor_reference;


### PR DESCRIPTION
Add helper functions to find objects in a tour/tour stops.
Use db_query replacements.