### PR TITLE
remove define constants for date format types 

### DIFF
--- a/sites/all/modules/custom/aicapp/aicapp.info
+++ b/sites/all/modules/custom/aicapp/aicapp.info
@@ -1,6 +1,9 @@
 name = AIC App
 description = Custom module for loading and generating data to the AIC museum mobile app.
 package = AIC Custom Modules
-version = VERSION
+version = 7.x.2.0
 core = 7.x
+files[] = aicapp.install
 files[] = aicapp.module
+files[] = includes/aicapp.admin.inc
+files[] = includes/aicapp.form.alter.inc

--- a/sites/all/modules/custom/aicapp/aicapp.install
+++ b/sites/all/modules/custom/aicapp/aicapp.install
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Installation functions for the AICAPP module.
+ */
+
+/**
+ * Implements hook_update_N.
+ *
+ * Delete {system} records for modules that are no longer in the file system.
+ */
+function aicapp_update_7201() {
+  db_delete('system')
+    ->condition('name', 'wcreek', '=')
+    ->condition('type', 'module')
+    ->execute();
+  db_delete('system')
+    ->condition('name', 'aibatch', '=')
+    ->condition('type', 'module')
+    ->execute();
+}

--- a/sites/all/modules/custom/aicapp/aicapp.module
+++ b/sites/all/modules/custom/aicapp/aicapp.module
@@ -3090,6 +3090,6 @@ function aicapp_date_formats() {
  */
 function aicapp_date_format_types() {
   $types = array();
-  $types[AICAPP_DATE_TYPE] = t('Short Date, 12 Hour Time');
+  $types['aicapp_date_type'] = t('Short Date, 12 Hour Time');
   return $types;
 }

--- a/sites/all/modules/custom/aicapp/aicapp.module
+++ b/sites/all/modules/custom/aicapp/aicapp.module
@@ -17,6 +17,8 @@
  * Implements  hook_init().
  */
 function aicapp_init() {
+  global $language;
+  define('AICAPP_DEFAULT_LANG', $language->language);
   define('AICAPP_ARTWORK_QUERY', 'artwork');
   define('AICAPP_GALLERY_QUERY', 'gallery');
   define('AICAPP_IMAGE_SERVER', rtrim(variable_get('aicapp_image_server_url', 'https://lakeimagesweb.artic.edu/iiif/2'), '/'));
@@ -24,8 +26,6 @@ function aicapp_init() {
   define('AICAPP_IMAGE_CROP_ROTATION', 0);
   define('AICAPP_IMAGE_CROP_QUALITY', 'default');
   define('AICAPP_IMAGE_CROP_FORMAT', 'jpg');
-  global $language;
-  define('AICAPP_DEFAULT_LANG', $language->language);
   define('AICAPP_TYPE_AUDIO', 'audio');
   define('AICAPP_TYPE_OBJECT', 'object');
   define('AICAPP_TYPE_GALLERY', 'gallery');
@@ -44,8 +44,6 @@ function aicapp_init() {
   define('AICAPP_JSON_V2', variable_get('aicapp_json_version_2', 'v2'));
   define('AICAPP_TOUR_VOCABULARY_NAME', variable_get('aicapp_tour_vocabular_name', 'categories'));
   define('AICAPP_CURRENT_SERVER_FQDM', rtrim(variable_get('aicapp_env_fqdm', 'http://aicweb10.artic.edu'), '/'));
-  define('AICAPP_DATE_TYPE', 'aicapp_date_type');
-  define('AICAPP_DATE_FORMAT', 'M j Y - g:ia');
 }
 
 /**
@@ -3080,8 +3078,8 @@ function aicapp_object_limit_js($form, $form_state) {
 function aicapp_date_formats() {
   $formats = array();
   $formats[] = array(
-    'type' => AICAPP_DATE_TYPE,
-    'format' => AICAPP_DATE_FORMAT,
+    'type' => 'aicapp_date_type',
+    'format' => 'M j Y - g:ia',
     'locales' => array(),
   );
   return $formats;


### PR DESCRIPTION
Because these were inside of hook_intit(), they weren't available during update.php tasks.
Also add a hook_n_update to remove unused modules from the system table.