### PR TITLE
Force https scheme on urls

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use A17\Twill\Facades\TwillNavigation;
 use A17\Twill\View\Components\Navigation\NavigationLink;
 use App\Libraries\Api\Consumers\GuzzleApiConsumer;
 use App\Libraries\DamsImageService;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -32,6 +33,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        URL::forceScheme('https');
         TwillNavigation::addLink(
             NavigationLink::make()->forModule('exhibitions')
         );


### PR DESCRIPTION
For some reason, Twill generates route urls as `http` instead of `https`. In the app provider we can force all generated urls to use `https`.

I decided to go with this implementation instead of the one nikhil discovered because it puts the solution right next to the Twill navigation URLs which are causing the problem.