### PR TITLE
Retrieve correct record counts for augmented models

### DIFF
--- a/app/Repositories/Api/BaseApiRepository.php
+++ b/app/Repositories/Api/BaseApiRepository.php
@@ -59,17 +59,16 @@ abstract class BaseApiRepository extends ModuleRepository
      */
     public function getCountByStatusSlug(string $slug, array $scope = []): int
     {
-        $dbQuery = $this->model->newQuery();
-        $apiQuery = $this->model->getApiModel()->newQuery();
+        $query = $this->model->newQuery();
         switch ($slug) {
             case 'all':
-                return $dbQuery->count() + $apiQuery->count();
+                return $this->model->getApiModel()->newQuery()->count();
             case 'published':
-                return $dbQuery->published()->count();
+                return $query->published()->count();
             case 'draft':
-                return $dbQuery->draft()->count();
+                return $query->draft()->count();
             case 'trash':
-                return $dbQuery->onlyTrashed()->count();
+                return $query->onlyTrashed()->count();
         }
 
         foreach ($this->traitsMethods(__FUNCTION__) as $method) {

--- a/app/Repositories/Api/BaseApiRepository.php
+++ b/app/Repositories/Api/BaseApiRepository.php
@@ -59,16 +59,17 @@ abstract class BaseApiRepository extends ModuleRepository
      */
     public function getCountByStatusSlug(string $slug, array $scope = []): int
     {
-        $query = $this->model->newQuery();
+        $dbQuery = $this->model->newQuery();
+        $apiQuery = $this->model->getApiModel()->newQuery();
         switch ($slug) {
             case 'all':
-                return $query->count();
+                return $dbQuery->count() + $apiQuery->count();
             case 'published':
-                return $query->published()->count();
+                return $dbQuery->published()->count();
             case 'draft':
-                return $query->draft()->count();
+                return $dbQuery->draft()->count();
             case 'trash':
-                return $query->onlyTrashed()->count();
+                return $dbQuery->onlyTrashed()->count();
         }
 
         foreach ($this->traitsMethods(__FUNCTION__) as $method) {


### PR DESCRIPTION
To get the correct number of augmented models, we need to count the records in the API instead of the DB.