### PR TITLE
Use limit=0 in query to retrieve just the results metadata

### DIFF
--- a/app/Libraries/Api/Builders/ApiQueryBuilder.php
+++ b/app/Libraries/Api/Builders/ApiQueryBuilder.php
@@ -533,7 +533,7 @@ class ApiQueryBuilder
      */
     public function count($endpoint = null): int
     {
-        return $this->forPage(1, 1)->get([], $endpoint)->getMetadata('pagination')->total;
+        return $this->limit(0)->get([], $endpoint)->getMetadata('pagination')->total;
     }
 
     public function getPaginationData()

--- a/app/Libraries/Api/Builders/Connection/AicConnection.php
+++ b/app/Libraries/Api/Builders/Connection/AicConnection.php
@@ -123,7 +123,6 @@ class AicConnection implements ApiConnectionInterface
                 $response = $this->client->request($verb, $endpoint, $options);
                 if (config('api.logger')) {
                     \Log::info('cache ttl = ' . $ttl . ' seconds');
-                    \Log::info(print_r((array) $response->body, true));
                 }
                 return $response;
             });


### PR DESCRIPTION
As per the Pagination section in our API documentation: http://api.artic.edu/docs/#pagination