### PR TITLE
Add transcript and locale to Sound model

### DIFF
--- a/app/Http/Controllers/Twill/BaseApiController.php
+++ b/app/Http/Controllers/Twill/BaseApiController.php
@@ -232,11 +232,40 @@ class BaseApiController extends ModuleController
     public function getForm(TwillModelContract $model): Form
     {
         $model->refreshApi();
-        $form = Form::make()
+        $content = Form::make()
+            ->add(Input::make()
+                    ->name('title')
+                    ->placeholder($model->getApiModel()->title ?? ''))
+            ->merge($this->additionalFormFields($model, $model->getApiModel()));
+        return parent::getForm($model)
             ->addFieldset(
                 Fieldset::make()
-                    ->title('Datahub')
+                    ->title('Content')
+                    ->id('content')
+                    ->fields($content->toArray())
+            );
+    }
+
+    protected function additionalFormFields($model, $apiModel): Form
+    {
+        return new Form();
+    }
+
+    public function getSideFieldSets(TwillModelContract $model): Form
+    {
+        return parent::getSideFieldSets($model)
+            // For some reason, the side form will not render unless there is a
+            // field in the default Content fieldset. 🤷
+            ->add(
+                Input::make()
+                    ->name('id')
+                    ->disabled()
+                    ->note('readonly')
+            )
+            ->addFieldset(
+                Fieldset::make()
                     ->id('datahub')
+                    ->title('Datahub')
                     ->closed()
                     ->fields([
                         Input::make()
@@ -251,8 +280,8 @@ class BaseApiController extends ModuleController
             )
             ->addFieldset(
                 Fieldset::make()
-                    ->title('Timestamps')
                     ->id('timestamps')
+                    ->title('Timestamps')
                     ->closed()
                     ->fields([
                         Input::make()
@@ -265,23 +294,6 @@ class BaseApiController extends ModuleController
                             ->note('readonly'),
                     ])
             );
-        $content = Form::make()
-            ->add(Input::make()
-                    ->name('title')
-                    ->placeholder($model->getApiModel()->title))
-            ->merge($this->additionalFormFields($model, $model->getApiModel()));
-        $form->addFieldset(
-            Fieldset::make()
-                ->title('Content')
-                ->id('content')
-                ->fields($content->toArray())
-        );
-        return $form;
-    }
-
-    protected function additionalFormFields($model, $apiModel): Form
-    {
-        return new Form();
     }
 
     /**

--- a/app/Http/Controllers/Twill/SoundController.php
+++ b/app/Http/Controllers/Twill/SoundController.php
@@ -92,6 +92,6 @@ class SoundController extends BaseApiController
                             ->view('admin.fields.audio')
                             ->withAdditionalParams(['src' => $sound->getApiModel()->content]),
                     ])
-        );
+            );
     }
 }

--- a/app/Http/Controllers/Twill/SoundController.php
+++ b/app/Http/Controllers/Twill/SoundController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\Twill;
 
+use A17\Twill\Services\Forms\BladePartial;
+use A17\Twill\Services\Forms\Fields\Input;
+use A17\Twill\Services\Forms\Fields\Radios;
+use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Text;
 use A17\Twill\Services\Listings\TableColumns;
-use A17\Twill\Services\Forms\Fields\Input;
-use A17\Twill\Services\Forms\Form;
 
 class SoundController extends BaseApiController
 {
@@ -25,26 +27,55 @@ class SoundController extends BaseApiController
             ->add(
                 Text::make()
                     ->field('content')
+                    ->title('Audio')
                     ->customRender(function ($sound) {
-                        return "<audio controls src='$sound->content'></audio>";
+                        return view('admin.audio-controls', ['src' => $sound->content])->render();
                     })
                     ->optional()
+            )
+            ->add(
+                Text::make()
+                    ->field('locale')
+                    ->title('Language')
+                    ->optional()
+                    ->hide()
+            )
+            ->add(
+                Text::make()
+                    ->field('transcript')
+                    ->optional()
+                    ->hide()
             );
     }
 
     protected function additionalFormFields($sound, $apiSound): Form
     {
-        $apiValues = array_map(
-            fn ($value) => $value ?? (string) $value,
-            $apiSound->getAttributes()
-        );
         return Form::make()
+            ->add(
+                BladePartial::make()
+                    ->view('admin.fields.audio')
+                    ->withAdditionalParams(['src' => $apiSound->content])
+            )
             ->add(
                 Input::make()
                     ->name('content')
-                    ->placeholder($apiValues['content'])
+                    ->label('URL')
+                    ->placeholder($apiSound->content)
                     ->disabled()
                     ->note('readonly')
+            )
+            ->add(
+                Radios::make()
+                    ->name('locale')
+                    ->label('Language')
+                    ->options(
+                        collect(config('translatable.locales'))
+                            ->mapWithKeys(fn ($language) => [$language => $language])
+                            ->toArray()
+                    )
+                    ->default(config('app.locale'))
+                    ->inline()
+                    ->border()
             )
             ->add(
                 Input::make()

--- a/app/Http/Controllers/Twill/SoundController.php
+++ b/app/Http/Controllers/Twill/SoundController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Twill;
 use A17\Twill\Services\Forms\BladePartial;
 use A17\Twill\Services\Forms\Fields\Input;
 use A17\Twill\Services\Forms\Fields\Radios;
+use A17\Twill\Services\Forms\Fieldset;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Text;
 use A17\Twill\Services\Listings\TableColumns;
@@ -52,14 +53,9 @@ class SoundController extends BaseApiController
     {
         return Form::make()
             ->add(
-                BladePartial::make()
-                    ->view('admin.fields.audio')
-                    ->withAdditionalParams(['src' => $apiSound->content])
-            )
-            ->add(
                 Input::make()
                     ->name('content')
-                    ->label('URL')
+                    ->label('Url')
                     ->placeholder($apiSound->content)
                     ->disabled()
                     ->note('readonly')
@@ -82,5 +78,20 @@ class SoundController extends BaseApiController
                     ->name('transcript')
                     ->type('textarea')
             );
+    }
+
+    public function getSideFieldSets($sound): Form
+    {
+        return parent::getSideFieldSets($sound)
+            ->addFieldset(
+                Fieldset::make()
+                    ->id('audio_player')
+                    ->title('Audio Player')
+                    ->fields([
+                        BladePartial::make()
+                            ->view('admin.fields.audio')
+                            ->withAdditionalParams(['src' => $sound->getApiModel()->content]),
+                    ])
+        );
     }
 }

--- a/app/Libraries/Api/Models/BaseApiModel.php
+++ b/app/Libraries/Api/Models/BaseApiModel.php
@@ -607,7 +607,7 @@ abstract class BaseApiModel implements TwillModelContract, ArrayAccess, Arrayabl
     /**
      * Get an attribute from the $attributes array.
      */
-    protected function getAttributeFromArray(string $key): mixed
+    protected function getAttributeFromArray(string $key)
     {
         if (array_key_exists($key, $this->attributes)) {
             return $this->attributes[$key];

--- a/app/Models/Api/Sound.php
+++ b/app/Models/Api/Sound.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\Api;
 
-use App\Helpers\StringHelpers;
 use App\Libraries\Api\Models\BaseApiModel;
 
 class Sound extends BaseApiModel
@@ -18,6 +17,16 @@ class Sound extends BaseApiModel
     public function getTypeAttribute()
     {
         return 'sound';
+    }
+
+    public function getLocaleAttribute()
+    {
+        return $this->getAugmentedModel()?->locale;
+    }
+
+    public function getTranscriptAttribute()
+    {
+        return $this->getAugmentedModel()?->transcript;
     }
 
     public function __toString(): string

--- a/app/Models/Sound.php
+++ b/app/Models/Sound.php
@@ -16,5 +16,7 @@ class Sound extends AbstractModel
         'datahub_id',
         'title',
         'content',
+        'locale',
+        'transcript',
     ];
 }

--- a/database/migrations/2023_08_25_134412_revise_transcripts.php
+++ b/database/migrations/2023_08_25_134412_revise_transcripts.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sounds', function (Blueprint $table) {
+            $table->string('locale', 10);
+            $table->text('transcript');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sounds', function (Blueprint $table) {
+            $table->dropColumn('locale');
+            $table->dropColumn('transcript');
+        });
+    }
+};

--- a/resources/views/admin/audio-controls.blade.php
+++ b/resources/views/admin/audio-controls.blade.php
@@ -1,0 +1,1 @@
+<audio controls src="{{ $src }}" @style(['width: 100%'])></audio>

--- a/resources/views/admin/audio-controls.blade.php
+++ b/resources/views/admin/audio-controls.blade.php
@@ -1,1 +1,5 @@
-<audio controls src="{{ $src }}" @style(['width: 100%'])></audio>
+@if ($src)
+    <audio controls src="{{ $src }}" @style(['width: 100%'])></audio>
+@else
+    <span>No audio available</span>
+@endif

--- a/resources/views/admin/fields/audio.blade.php
+++ b/resources/views/admin/fields/audio.blade.php
@@ -1,0 +1,6 @@
+<div class="audio-wrapper" @style(['margin-top: 35px'])>
+    <label @style(['display: block', 'margin-bottom: 10px'])>Audio</label>
+    <div>
+        @include('admin.audio-controls')
+    </div>
+</div>


### PR DESCRIPTION
This change adds the `transcript` attribute back to the `Sound` model, as well as a `locale`. It also includes the addition of the audio player on the edit form.