### PR TITLE
Use specific search query for objects, not general search [MA-122]

### DIFF
--- a/app/Http/Controllers/Twill/ArtworkController.php
+++ b/app/Http/Controllers/Twill/ArtworkController.php
@@ -30,7 +30,7 @@ class ArtworkController extends BaseApiController
     {
         parent::setUpController();
 
-        $this->setSearchColumns(['title', 'artist_display', 'datahub_id', 'main_reference_number']);
+        $this->setSearchColumns(['title', 'artist_display', 'id', 'main_reference_number']);
 
         $this->eagerLoadListingRelations(['gallery']);
     }

--- a/app/Libraries/Api/Filters/Search.php
+++ b/app/Libraries/Api/Filters/Search.php
@@ -13,8 +13,26 @@ class Search extends FreeTextSearch
     public function applyFilter(Builder $builder): Builder
     {
         if (!empty($this->searchString) && $this->searchColumns !== []) {
-            // \App\Libraries\Api\Models\BaseApiModel with \App\Libraries\Api\Models\Behaviors\HasApiCalls::search()
-            return $builder->getModel()->search($this->searchString);
+
+            $shoulds = [];
+            foreach ($this->searchColumns as $col) {
+                if ($col != 'id' || is_numeric($this->searchString)) {
+                    $shoulds[] = [
+                        'match' => [
+                            $col => $this->searchString,
+                        ],
+                    ];
+                }
+            }
+            $params = [
+                'bool' => [
+                    'should' => $shoulds,
+                    'minimum_should_match' => 1,
+                ],
+            ];
+
+            // \App\Libraries\Api\Models\BaseApiModel with \App\Libraries\Api\Models\Behaviors\HasApiCalls::rawSearch()
+            return $builder->getModel()->rawSearch($params);
         }
 
         return $builder;

--- a/app/Libraries/Api/Filters/Search.php
+++ b/app/Libraries/Api/Filters/Search.php
@@ -13,7 +13,6 @@ class Search extends FreeTextSearch
     public function applyFilter(Builder $builder): Builder
     {
         if (!empty($this->searchString) && $this->searchColumns !== []) {
-
             $shoulds = [];
             foreach ($this->searchColumns as $col) {
                 if ($col != 'id' || is_numeric($this->searchString)) {

--- a/app/Libraries/Api/Models/Behaviors/HasApiCalls.php
+++ b/app/Libraries/Api/Models/Behaviors/HasApiCalls.php
@@ -47,6 +47,13 @@ trait HasApiCalls
     }
 
     /**
+     * Begin querying the model.
+     */
+    public static function rawSearch($value): ApiModelBuilder
+    {
+        return (new static())->newQuery()->rawSearch($value);
+    }
+    /**
      * Get a new query builder for the model's table.
      *
      * @return App\Libraries\Api\Builders\ApiModelBuilder


### PR DESCRIPTION
This PR sends a custom Elasticsearch query when searching by objects rather than using the API's general query. Specifically to allow users to search by ID.