### PR TITLE
Fix audio browser on selector edit page

### DIFF
--- a/app/Models/Selector.php
+++ b/app/Models/Selector.php
@@ -6,6 +6,7 @@ use A17\Twill\Models\Model;
 use App\Models\Behaviors\HasApiRelations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -15,6 +16,7 @@ use Illuminate\Support\Facades\DB;
 class Selector extends Model
 {
     use HasApiRelations;
+    use HasFactory;
 
     protected $fillable = [
         'notes',

--- a/app/Repositories/AudioRepository.php
+++ b/app/Repositories/AudioRepository.php
@@ -34,8 +34,6 @@ class AudioRepository extends BaseApiRepository
                 // relationship, so give it an arbitrary one.
                 $selector->audio()->attach($apiRelation, ['relation' => 'audio', 'position' => 0]);
             }
-        } else {
-            $audio->apiRelation?->morph()->delete();
         }
         parent::afterSave($audio, $fields);
     }

--- a/app/Repositories/SelectorRepository.php
+++ b/app/Repositories/SelectorRepository.php
@@ -2,9 +2,8 @@
 
 namespace App\Repositories;
 
-use A17\Twill\Repositories\ModuleRepository;
-use App\Models\Api\Audio;
 use App\Models\Selector;
+use App\Repositories\ModuleRepository;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 

--- a/database/factories/SelectorFactory.php
+++ b/database/factories/SelectorFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SelectorFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'number' => fake()->unique()->randomNumber(nbDigits: 3),
+        ];
+    }
+}

--- a/tests/Browser/AudioTest.php
+++ b/tests/Browser/AudioTest.php
@@ -11,17 +11,12 @@ class AudioTest extends DuskTestCase
 {
     use DatabaseTruncation;
 
-    public function setUp(): void
-    {
-        parent::setUp();
-        $this->authenticate();
-    }
-
     public function test_user_can_choose_an_audio_from_the_listing(): void
     {
         $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
         $this->browse(function (Browser $browser) use ($test) {
-            $browser->visit('/admin')
+            $browser->loginAs($this->user(), 'twill_users')
+                ->visit('/admin')
                 ->assertRouteIs('twill.dashboard')
                 ->clickLink('Audio')
                 ->assertRouteIs('twill.audio.index')

--- a/tests/Browser/AudioTest.php
+++ b/tests/Browser/AudioTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Browser;
+
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+use Illuminate\Support\Str;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class AudioTest extends DuskTestCase
+{
+    use DatabaseTruncation;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
+    public function test_user_can_choose_an_audio_from_the_listing(): void
+    {
+        $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
+        $this->browse(function (Browser $browser) use ($test) {
+            $browser->visit('/admin')
+                ->assertRouteIs('twill.dashboard')
+                ->clickLink('Audio')
+                ->assertRouteIs('twill.audio.index')
+                ->screenshot("$test 1 - Audio Listing")
+                ->click('.tablecell a') // The title of the first item
+                ->screenshot("$test 2 - Audio Edit");
+        });
+    }
+}

--- a/tests/Browser/AuthenticationTest.php
+++ b/tests/Browser/AuthenticationTest.php
@@ -26,9 +26,9 @@ class AuthenticationTest extends DuskTestCase
 
     public function test_user_can_logout(): void
     {
-        $this->authenticate();
         $this->browse(function (Browser $browser) {
-            $browser->visit('/admin')
+            $browser->loginAs($this->user(), 'twill_users')
+                ->visit('/admin')
                 ->assertRouteIs('twill.dashboard')
                 ->clickLink('Logout')
                 ->assertRouteIs('twill.login.form');

--- a/tests/Browser/SelectorTest.php
+++ b/tests/Browser/SelectorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\Selector;
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+use Illuminate\Support\Str;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class SelectorTest extends DuskTestCase
+{
+    use DatabaseTruncation;
+
+    const TWILL_DATA_LOADED = 'window["TWILL"].STORE.datatable != {}';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->authenticate();
+    }
+
+    public function test_user_can_choose_a_selector_from_the_listing(): void
+    {
+        $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
+        $selector = Selector::factory()->count(3)->create()->first();
+        $this->browse(function (Browser $browser) use ($selector, $test) {
+            $browser->visit('/admin')
+                ->assertRouteIs('twill.dashboard')
+                ->clickLink('Selectors')
+                ->assertRouteIs('twill.selectors.index')
+                ->waitUntil(self::TWILL_DATA_LOADED)
+                ->screenshot("$test 1 - Selector Listing")
+                ->clickLink($selector->number)
+                ->assertRouteIs('twill.selectors.edit', ['selector' => $selector->first()])
+                ->waitUntil(self::TWILL_DATA_LOADED)
+                ->screenshot("$test 2 - Selector Edit");
+        });
+    }
+
+    public function test_user_can_add_audio_to_selector(): void
+    {
+        $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
+        $selector = Selector::factory()->create();
+        $this->browse(function (Browser $browser) use ($selector, $test) {
+            $browser->visit("admin/selectors/$selector->id/edit")
+                ->waitUntil(self::TWILL_DATA_LOADED)
+                ->screenshot("$test 1 - Selector Edit No Audio")
+                ->press('Add audio')
+                ->waitFor('.itemlist__table') // Audio browser data table
+                ->check('.itemlist__row') // First item in list
+                ->screenshot("$test 2 - Selector Edit Audio Select")
+                ->press('Attach audio')
+                ->press('Update')
+                ->assertSee('Podcast: Edward Hopper')
+                ->screenshot("$test 3 - Selector Edit Audio Attach")
+                ->refresh()
+                ->waitUntil(self::TWILL_DATA_LOADED)
+                ->assertSee('Podcast: Edward Hopper')
+                ->screenshot("$test 4 - Selector Edit Audio Refresh");
+        });
+    }
+}

--- a/tests/Browser/SelectorTest.php
+++ b/tests/Browser/SelectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser;
 
+use App\Models\Api\Audio;
 use App\Models\Selector;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
 use Illuminate\Support\Str;
@@ -42,7 +43,8 @@ class SelectorTest extends DuskTestCase
     {
         $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
         $selector = Selector::factory()->create();
-        $this->browse(function (Browser $browser) use ($selector, $test) {
+        $audio = Audio::query()->limit(1)->get()->first();
+        $this->browse(function (Browser $browser) use ($selector, $audio, $test) {
             $browser->visit("admin/selectors/$selector->id/edit")
                 ->waitUntil(self::TWILL_DATA_LOADED)
                 ->screenshot("$test 1 - Selector Edit No Audio")
@@ -52,11 +54,11 @@ class SelectorTest extends DuskTestCase
                 ->screenshot("$test 2 - Selector Edit Audio Select")
                 ->press('Attach audio')
                 ->press('Update')
-                ->assertSee('Podcast: Edward Hopper')
+                ->assertSee($audio->title)
                 ->screenshot("$test 3 - Selector Edit Audio Attach")
                 ->refresh()
                 ->waitUntil(self::TWILL_DATA_LOADED)
-                ->assertSee('Podcast: Edward Hopper')
+                ->assertSee($audio->title)
                 ->screenshot("$test 4 - Selector Edit Audio Refresh");
         });
     }

--- a/tests/Browser/SelectorTest.php
+++ b/tests/Browser/SelectorTest.php
@@ -15,18 +15,13 @@ class SelectorTest extends DuskTestCase
 
     const TWILL_DATA_LOADED = 'window["TWILL"].STORE.datatable != {}';
 
-    public function setUp(): void
-    {
-        parent::setUp();
-        $this->authenticate();
-    }
-
     public function test_user_can_choose_a_selector_from_the_listing(): void
     {
         $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
         $selector = Selector::factory()->count(3)->create()->first();
         $this->browse(function (Browser $browser) use ($selector, $test) {
-            $browser->visit('/admin')
+            $browser->loginAs($this->user(), 'twill_users')
+                ->visit('/admin')
                 ->assertRouteIs('twill.dashboard')
                 ->clickLink('Selectors')
                 ->assertRouteIs('twill.selectors.index')
@@ -45,7 +40,8 @@ class SelectorTest extends DuskTestCase
         $selector = Selector::factory()->create();
         $audio = Audio::query()->limit(1)->get()->first();
         $this->browse(function (Browser $browser) use ($selector, $audio, $test) {
-            $browser->visit("admin/selectors/$selector->id/edit")
+            $browser->loginAs($this->user(), 'twill_users')
+                ->visit("admin/selectors/$selector->id/edit")
                 ->waitUntil(self::TWILL_DATA_LOADED)
                 ->screenshot("$test 1 - Selector Edit No Audio")
                 ->press('Add audio')

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Collection;
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
-use Laravel\Dusk\Browser;
 use Laravel\Dusk\TestCase as BaseTestCase;
 
 abstract class DuskTestCase extends BaseTestCase
@@ -36,20 +35,6 @@ abstract class DuskTestCase extends BaseTestCase
         return $this->user ?? User::factory()->create();
     }
 
-    /**
-     * TODO: Figure out how to get $this->login() and logout() to work with the
-     * Twill User model. This simulates the functionality of login() by
-     * manually visiting the long page and filling in the form.
-     */
-    protected function authenticate(): void
-    {
-        $this->browse(function (Browser $browser) {
-            $browser->visit('/admin')
-                ->type('email', $this->user()->email)
-                ->type('password', 'password')
-                ->press('Login');
-        });
-    }
     /**
      * Create the RemoteWebDriver instance.
      */


### PR DESCRIPTION
This fixes the audio browser field on the selector edit page to properly display the attached audio(s).

![Test User Can Add Audio To Selector 1 - Selector Edit No Audio](https://github.com/art-institute-of-chicago/aic-mobile-cms/assets/2098951/369e0cde-6c90-4e1a-818c-78c3062925bb)
![Test User Can Add Audio To Selector 2 - Selector Edit Audio Select](https://github.com/art-institute-of-chicago/aic-mobile-cms/assets/2098951/fafb807b-b53b-461d-9cee-90c1d943356f)
![Test User Can Add Audio To Selector 3 - Selector Edit Audio Attach](https://github.com/art-institute-of-chicago/aic-mobile-cms/assets/2098951/04703e5a-8445-4e80-9e6f-ec10418a041b)
![Test User Can Add Audio To Selector 4 - Selector Edit Audio Refresh](https://github.com/art-institute-of-chicago/aic-mobile-cms/assets/2098951/b4490fb0-4746-41a5-bd43-1cc4a014cb81)

