### PR TITLE
Add WYSIWYG formatting to audio, stop, and tour fields

### DIFF
--- a/app/Http/Controllers/Twill/AudioController.php
+++ b/app/Http/Controllers/Twill/AudioController.php
@@ -7,6 +7,7 @@ use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Forms\BladePartial;
 use A17\Twill\Services\Forms\Fields\Input;
 use A17\Twill\Services\Forms\Fields\Radios;
+use A17\Twill\Services\Forms\Fields\Wysiwyg;
 use A17\Twill\Services\Forms\Fieldset;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Text;
@@ -93,9 +94,10 @@ class AudioController extends BaseApiController
                     ->border()
             )
             ->add(
-                Input::make()
+                Wysiwyg::make()
                     ->name('transcript')
                     ->type('textarea')
+                    ->toolbarOptions(['bold', 'italic'])
             );
     }
 

--- a/app/Http/Controllers/Twill/AudioController.php
+++ b/app/Http/Controllers/Twill/AudioController.php
@@ -70,6 +70,24 @@ class AudioController extends BaseApiController
             );
     }
 
+    public function getForm(TwillModelContract $audio): Form
+    {
+        $content = Form::make()
+            ->add(
+                Wysiwyg::make()
+                    ->name('title')
+                    ->required()
+                    ->toolbarOptions(['bold', 'italic'])
+            )
+            ->merge($this->additionalFormFields($audio, $audio->getApiModel()));
+        return Form::make()->addFieldset(
+            Fieldset::make()
+                ->title('Content')
+                ->id('content')
+                ->fields($content->toArray())
+        );
+    }
+
     protected function additionalFormFields($audio, $apiSound): Form
     {
         return Form::make()

--- a/app/Http/Controllers/Twill/StopController.php
+++ b/app/Http/Controllers/Twill/StopController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Twill;
 
 use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Forms\Fields\Browser;
+use A17\Twill\Services\Forms\Fields\Wysiwyg;
+use A17\Twill\Services\Forms\Fieldset;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Relation;
 use A17\Twill\Services\Listings\TableColumns;
@@ -57,6 +59,25 @@ class StopController extends BaseController
                     ->title('Selector Number')
                     ->relation('selector')
             );
+    }
+
+    public function getForm(TwillModelContract $stop): Form
+    {
+        $content = Form::make()
+            ->add(
+                Wysiwyg::make()
+                    ->name('title')
+                    ->required()
+                    ->translatable()
+                    ->toolbarOptions(['bold', 'italic'])
+            )
+            ->merge($this->additionalFormFields($stop));
+        return Form::make()->addFieldset(
+            Fieldset::make()
+                ->title('Content')
+                ->id('content')
+                ->fields($content->toArray())
+        );
     }
 
     public function additionalFormFields(TwillModelContract $stop): Form

--- a/app/Http/Controllers/Twill/TourController.php
+++ b/app/Http/Controllers/Twill/TourController.php
@@ -2,16 +2,19 @@
 
 namespace App\Http\Controllers\Twill;
 
+use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Forms\Fields\Browser;
 use A17\Twill\Services\Forms\Fields\Input;
+use A17\Twill\Services\Forms\Fields\Wysiwyg;
+use A17\Twill\Services\Forms\Fieldset;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Relation;
 use A17\Twill\Services\Listings\Columns\Text;
 use A17\Twill\Services\Listings\TableColumns;
 use App\Http\Controllers\Twill\Columns\ApiRelation;
 use App\Http\Controllers\Twill\Columns\RelationCount;
-use App\Models\Selector;
 use App\Models\Audio;
+use App\Models\Selector;
 use App\Models\Tour;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
@@ -79,6 +82,25 @@ class TourController extends BaseController
             );
     }
 
+    public function getForm(TwillModelContract $tour): Form
+    {
+        $content = Form::make()
+            ->add(
+                Wysiwyg::make()
+                    ->name('title')
+                    ->required()
+                    ->translatable()
+                    ->toolbarOptions(['bold', 'italic'])
+            )
+            ->merge($this->additionalFormFields($tour));
+        return Form::make()->addFieldset(
+            Fieldset::make()
+                ->title('Content')
+                ->id('content')
+                ->fields($content->toArray())
+        );
+    }
+
     public function additionalFormFields($tour): Form
     {
         return parent::additionalFormFields($tour)
@@ -90,18 +112,20 @@ class TourController extends BaseController
                     ->note('Coming Soon!')
             )
             ->add(
-                Input::make()
+                Wysiwyg::make()
                     ->name('intro')
                     ->type('textarea')
                     ->required()
                     ->translatable()
+                    ->toolbarOptions(['bold', 'italic'])
             )
             ->add(
-                Input::make()
+                Wysiwyg::make()
                     ->name('description')
                     ->type('textarea')
                     ->required()
                     ->translatable()
+                    ->toolbarOptions(['bold', 'italic'])
             )
             ->add(
                 Browser::make()

--- a/app/Models/Behaviors/HasApiModel.php
+++ b/app/Models/Behaviors/HasApiModel.php
@@ -23,13 +23,17 @@ trait HasApiModel
         return $this;
     }
 
-
     public function getApiModel()
     {
         if (!$this->apiModel) {
             $this->apiModel = $this->apiModelClass::query()->find($this->datahub_id);
         }
         return $this->apiModel;
+    }
+
+    public function getTitleAttribute(): string
+    {
+        return (string) ($this->attributes['title'] ?? $this->getApiModel()?->getAttribute('title'));
     }
 
     /**

--- a/app/Models/Behaviors/HasApiModel.php
+++ b/app/Models/Behaviors/HasApiModel.php
@@ -18,16 +18,17 @@ trait HasApiModel
      */
     public function refreshApi(): self
     {
-        if (!$this->apiModel) {
-            $this->apiModel = $this->apiModelClass::query()->find($this->datahub_id);
-            $this->augmentWithApiModel();
-        }
-
+        $this->getApiModel();
+        $this->augmentWithApiModel();
         return $this;
     }
 
+
     public function getApiModel()
     {
+        if (!$this->apiModel) {
+            $this->apiModel = $this->apiModelClass::query()->find($this->datahub_id);
+        }
         return $this->apiModel;
     }
 

--- a/app/Repositories/AudioRepository.php
+++ b/app/Repositories/AudioRepository.php
@@ -18,15 +18,8 @@ class AudioRepository extends BaseApiRepository
     public function getFormFields(TwillModelContract $audio): array
     {
         $fields = parent::getFormFields($audio);
-        $fields['title'] = $audio->title ?? $audio->getApiModel()?->title;
         $fields['selector_number'] = $audio->selector?->number;
         return $fields;
-    }
-
-    public function prepareFieldsBeforeSave($audio, $fields): array
-    {
-        $fields['title'] = $fields['title'] != $audio->getApiModel()?->title ? $fields['title'] : null;
-        return parent::prepareFieldsBeforeSave($audio, $fields);
     }
 
     public function afterSave(TwillModelContract $audio, array $fields): void

--- a/app/Repositories/AudioRepository.php
+++ b/app/Repositories/AudioRepository.php
@@ -18,8 +18,15 @@ class AudioRepository extends BaseApiRepository
     public function getFormFields(TwillModelContract $audio): array
     {
         $fields = parent::getFormFields($audio);
+        $fields['title'] = $audio->title ?? $audio->getApiModel()?->title;
         $fields['selector_number'] = $audio->selector?->number;
         return $fields;
+    }
+
+    public function prepareFieldsBeforeSave($audio, $fields): array
+    {
+        $fields['title'] = $fields['title'] != $audio->getApiModel()?->title ? $fields['title'] : null;
+        return parent::prepareFieldsBeforeSave($audio, $fields);
     }
 
     public function afterSave(TwillModelContract $audio, array $fields): void


### PR DESCRIPTION
The WYSIWYG fields have options for Bold, Italic, and Undo/Redo:
![Screenshot 2023-09-29 at 1 47 17 PM](https://github.com/art-institute-of-chicago/aic-mobile-cms/assets/2098951/d1a74446-85ee-477f-917c-72cff036a07f)
