### PR TITLE
Add images to collection objects, loan objects, and tours

### DIFF
--- a/app/Http/Controllers/Twill/BaseApiController.php
+++ b/app/Http/Controllers/Twill/BaseApiController.php
@@ -11,7 +11,6 @@ use A17\Twill\Services\Forms\Fieldset;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Boolean;
 use A17\Twill\Services\Listings\Columns\FeaturedStatus;
-use A17\Twill\Services\Listings\Columns\Image;
 use A17\Twill\Services\Listings\Columns\Languages;
 use A17\Twill\Services\Listings\Columns\PublishStatus;
 use A17\Twill\Services\Listings\Columns\ScheduledStatus;
@@ -20,11 +19,11 @@ use A17\Twill\Services\Listings\Filters\BasicFilter;
 use A17\Twill\Services\Listings\Filters\QuickFilter;
 use A17\Twill\Services\Listings\TableColumns;
 use App\Helpers\UrlHelpers;
+use App\Http\Controllers\Twill\Columns\ApiImage;
 use App\Libraries\Api\Filters\Search;
 use App\Repositories\Api\BaseApiRepository;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 class BaseApiController extends ModuleController
 {
@@ -156,7 +155,7 @@ class BaseApiController extends ModuleController
 
         if ($this->getIndexOption('showImage')) {
             $columns->add(
-                Image::make()
+                ApiImage::make()
                     ->field('thumbnail')
                     ->title(twillTrans('Image'))
             );

--- a/app/Http/Controllers/Twill/CollectionObjectController.php
+++ b/app/Http/Controllers/Twill/CollectionObjectController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Twill;
 
 use A17\Twill\Services\Forms\BladePartial;
 use A17\Twill\Services\Forms\Fields\Browser;
+use A17\Twill\Services\Forms\Fields\Medias;
 use A17\Twill\Services\Forms\Fields\Checkbox;
 use A17\Twill\Services\Forms\Fields\Input;
 use A17\Twill\Services\Forms\Fields\Map;
@@ -20,13 +21,12 @@ use Illuminate\Contracts\Database\Query\Builder;
 
 class CollectionObjectController extends BaseApiController
 {
-    private $galleries = [];
-
     protected function setUpController(): void
     {
         parent::setUpController();
         $this->eagerLoadListingRelations(['gallery']);
         $this->enableAugmentedModel();
+        $this->enableShowImage();
         $this->setDisplayName('Collection Object');
         $this->setModuleName('collectionObjects');
         $this->setSearchColumns(['title', 'artist_display', 'datahub_id', 'main_reference_number']);
@@ -121,12 +121,15 @@ class CollectionObjectController extends BaseApiController
         );
         return Form::make()
             ->add(
-                Input::make()
-                    ->name('image_id')
-                    ->label('Image')
-                    ->placeholder($apiValues['image_id'])
-                    ->disabled()
-                    ->note('Coming Soon!')
+                BladePartial::make()
+                    ->view('admin.fields.image')
+                    ->withAdditionalParams(['src' => $apiCollectionObject->imageFront('iiif')['src'] ?? ''])
+            )
+            ->add(
+                Medias::make()
+                    ->name('upload')
+                    ->label('Override Image')
+                    ->note('This will replace the image above')
             )
             ->add(
                 Input::make()

--- a/app/Http/Controllers/Twill/Columns/ApiImage.php
+++ b/app/Http/Controllers/Twill/Columns/ApiImage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Twill\Columns;
+
+use A17\Twill\Models\Contracts\TwillModelContract;
+use A17\Twill\Services\Listings\Columns\Image;
+use App\Models\Behaviors\HasMediasApi;
+use InvalidArgumentException;
+
+class ApiImage extends Image
+{
+    protected function getRenderValue(TwillModelContract $model): string
+    {
+        if (method_exists($model, 'getApiModel')) {
+            $model = $model->getApiModel();
+        }
+        if (!classHasTrait($model::class, HasMediasApi::class)) {
+            throw new InvalidArgumentException('Cannot use image column on model not implementing HasMediasApi trait');
+        }
+        if ($renderFunction = $this->render) {
+            return $renderFunction($model);
+        }
+
+        return $this->getThumbnail($model);
+    }
+}

--- a/app/Http/Controllers/Twill/LoanObjectController.php
+++ b/app/Http/Controllers/Twill/LoanObjectController.php
@@ -6,6 +6,7 @@ use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Forms\Fields\Browser;
 use A17\Twill\Services\Forms\Fields\Input;
 use A17\Twill\Services\Forms\Fields\Map;
+use A17\Twill\Services\Forms\Fields\Medias;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Text;
 use A17\Twill\Services\Listings\TableColumns;
@@ -18,6 +19,7 @@ class LoanObjectController extends BaseController
     {
         $this->disablePermalink();
         $this->disablePublish();
+        $this->enableShowImage();
         $this->setModuleName('loanObjects');
         $this->setSearchColumns(['main_reference_number', 'title', 'artist_display']);
     }
@@ -68,18 +70,17 @@ class LoanObjectController extends BaseController
                     })
                     ->optional()
                     ->hide()
-            )
-            ->add(
-                Text::make()
-                    ->optional()
-                    ->field('image')
-                    ->hide()
             );
     }
 
     public function additionalFormFields(TwillModelContract $object): Form
     {
         return parent::additionalFormFields($object)
+            ->add(
+                Medias::make()
+                    ->name('upload')
+                    ->label('Image')
+            )
             ->add(
                 Input::make()
                     ->name('artist_display')

--- a/app/Http/Controllers/Twill/TourController.php
+++ b/app/Http/Controllers/Twill/TourController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Twill;
 use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Forms\Fields\Browser;
 use A17\Twill\Services\Forms\Fields\Input;
+use A17\Twill\Services\Forms\Fields\Medias;
 use A17\Twill\Services\Forms\Fields\Wysiwyg;
 use A17\Twill\Services\Forms\Fieldset;
 use A17\Twill\Services\Forms\Form;
@@ -25,6 +26,7 @@ class TourController extends BaseController
     {
         parent::setUpController();
         $this->enableReorder();
+        $this->enableShowImage();
         $this->setModelName('Tour');
         $this->setModuleName('tours');
     }
@@ -105,11 +107,9 @@ class TourController extends BaseController
     {
         return parent::additionalFormFields($tour)
             ->add(
-                Input::make()
-                    ->name('image_url')
+                Medias::make()
+                    ->name('upload')
                     ->label('Image')
-                    ->disabled()
-                    ->note('Coming Soon!')
             )
             ->add(
                 Wysiwyg::make()

--- a/app/Models/Api/CollectionObject.php
+++ b/app/Models/Api/CollectionObject.php
@@ -3,9 +3,12 @@
 namespace App\Models\Api;
 
 use App\Libraries\Api\Models\BaseApiModel;
+use App\Models\Behaviors\HasMediasApi;
 
 class CollectionObject extends BaseApiModel
 {
+    use HasMediasApi;
+
     protected array $endpoints = [
         'collection' => '/api/v1/artworks',
         'resource' => '/api/v1/artworks/{id}',
@@ -13,6 +16,17 @@ class CollectionObject extends BaseApiModel
     ];
 
     protected $augmentedModelClass = \App\Models\CollectionObject::class;
+
+    public $mediasParams = [
+        'iiif' => [
+            'default' => [
+                [
+                    'name' => 'default',
+                    'ratio' => 'default',
+                ],
+            ]
+        ],
+    ];
 
     public function getTypeAttribute()
     {

--- a/app/Models/Behaviors/HasMediasApi.php
+++ b/app/Models/Behaviors/HasMediasApi.php
@@ -50,15 +50,27 @@ trait HasMediasApi
         }
     }
 
-    public function defaultCmsImage($params = [])
+    public function cmsImage($role, $crop = 'default', $params = [])
     {
-        $image = DamsImageService::getImage($this, 'image_id', 100, 100);
+        $image = DamsImageService::getImage($this, $this->getImageField($role, $crop), $params['w'], $params['h']);
 
         if ($image) {
             return $image['src'];
         }
 
         return ImageService::getTransparentFallbackUrl($params);
+    }
+
+    public function defaultCmsImage($params = [])
+    {
+        return $this->cmsImage('iiif', 'default', ['w' => 100, 'h' => 100]);
+    }
+
+    public function getMediasParams(): array
+    {
+        return (isset($this->mediasParams) && is_array($this->mediasParams))
+            ? $this->mediasParams
+            : config('twill.default_crops');
     }
 
     protected function getImageField($role, $crop)

--- a/app/Models/CollectionObject.php
+++ b/app/Models/CollectionObject.php
@@ -22,6 +22,17 @@ class CollectionObject extends AbstractModel
 
     protected $apiModelClass = \App\Models\Api\CollectionObject::class;
 
+    public $mediasParams = [
+        'upload' => [
+            'default' => [
+                [
+                    'name' => 'default',
+                    'ratio' => 'default',
+                ],
+            ]
+        ],
+    ];
+
     protected $fillable = [
         'datahub_id',
         'title',
@@ -42,17 +53,8 @@ class CollectionObject extends AbstractModel
 
     protected $appends = [
         'latlng',
-        'image_url',
         // 'gallery_location',
     ];
-
-    /**
-     * TODO: Implement Images from API
-     */
-    public function getImageUrlAttribute(): string
-    {
-        return '';
-    }
 
     /**
      * TODO: Does this belong in a serializer?

--- a/app/Models/LoanObject.php
+++ b/app/Models/LoanObject.php
@@ -12,12 +12,22 @@ class LoanObject extends AbstractModel
     use HasApiRelations;
     use HasMedias;
 
+    public $mediasParams = [
+        'upload' => [
+            'default' => [
+                [
+                    'name' => 'default',
+                    'ratio' => 'default',
+                ],
+            ]
+        ],
+    ];
+
     protected $fillable = [
         'artist_display',
         'copyright_notice',
         'credit_line',
         'gallery_id',
-        'image',
         'latitude',
         'longitude',
         'main_reference_number',

--- a/app/Models/Tour.php
+++ b/app/Models/Tour.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
 
@@ -22,11 +21,22 @@ class Tour extends Model implements Sortable
 {
     use HasApiRelations;
     use HasFactory;
-    // use HasMedias;
+    use HasMedias;
     use HasPosition;
     use HasRelated;
     use HasRevisions;
     use HasTranslation;
+
+    public $mediasParams = [
+        'upload' => [
+            'default' => [
+                [
+                    'name' => 'default',
+                    'ratio' => 'default',
+                ],
+            ]
+        ],
+    ];
 
     protected $fillable = [
         'duration',

--- a/app/Repositories/CollectionObjectRepository.php
+++ b/app/Repositories/CollectionObjectRepository.php
@@ -2,11 +2,14 @@
 
 namespace App\Repositories;
 
+use A17\Twill\Repositories\Behaviors\HandleMedias;
 use App\Models\CollectionObject;
 use App\Repositories\Api\BaseApiRepository;
 
 class CollectionObjectRepository extends BaseApiRepository
 {
+    use HandleMedias;
+
     protected $apiBrowsers = [
         'gallery'
     ];

--- a/app/Repositories/LoanObjectRepository.php
+++ b/app/Repositories/LoanObjectRepository.php
@@ -7,7 +7,7 @@ use App\Models\LoanObject;
 
 class LoanObjectRepository extends ModuleRepository
 {
-    // use HandleMedias;
+    use HandleMedias;
 
     protected $apiBrowsers = [
         'gallery' => [

--- a/app/Repositories/TourRepository.php
+++ b/app/Repositories/TourRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories;
 
+use A17\Twill\Repositories\Behaviors\HandleMedias;
 use A17\Twill\Repositories\Behaviors\HandleRevisions;
 use A17\Twill\Repositories\Behaviors\HandleTranslations;
 use App\Models\Selector;
@@ -9,10 +10,14 @@ use App\Models\Tour;
 
 class TourRepository extends ModuleRepository
 {
+    use HandleMedias;
     use HandleRevisions;
     use HandleTranslations;
 
-    protected $relatedBrowsers = ['stops'];
+    protected $relatedBrowsers = [
+        'stops'
+    ];
+
     protected $apiBrowsers = [
         'gallery'
     ];

--- a/config/dams.php
+++ b/config/dams.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'base_url' => env('DAMS_BASE_URL', 'https://lakeimagesweb.artic.edu/iiif/'),
+    'cdn_enabled' => (bool) env('CDN_DAMS_ENABLED', false),
+    'base_url_cdn' => env('CDN_DAMS_BASE_URL', env('DAMS_BASE_URL', 'https://lakeimagesweb.artic.edu/iiif/')),
+    'version' => '2',
+];

--- a/config/twill.php
+++ b/config/twill.php
@@ -3,6 +3,13 @@
 return [
     'dashboard' => [
         'modules' => [
+            \App\Models\LoanObject::class => [
+                'name' => 'loanObjects',
+                'activity' => true,
+                'count' => true,
+                'create' => true,
+                'search' => true,
+            ],
             \App\Models\Selector::class => [
                 'name' => 'selectors',
                 'activity' => true,

--- a/database/migrations/2023_10_05_214846_drop_image_column.php
+++ b/database/migrations/2023_10_05_214846_drop_image_column.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('collection_objects', function (Blueprint $table) {
+            $table->dropColumn(['image_id']);
+        });
+
+        Schema::table('loan_objects', function (Blueprint $table) {
+            $table->dropColumn(['image']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('loan_objects', function (Blueprint $table) {
+            $table->string('image')->nullable();
+        });
+
+        Schema::table('collection_objects', function (Blueprint $table) {
+            $table->string('image_id')->nullable();
+        });
+    }
+};

--- a/resources/views/admin/fields/image.blade.php
+++ b/resources/views/admin/fields/image.blade.php
@@ -1,0 +1,6 @@
+<div class="image-wrapper" @style(['margin-top: 35px'])>
+    <label @style(['display: block', 'margin-bottom: 10px'])>Image</label>
+    <div>
+        <img src="{{ $src }}" @style(['width: 100%']) />
+    </div>
+</div>


### PR DESCRIPTION
This change allows for uploading an override image for collection objects and default images for loan objects and tours, and displaying images on the listing pages for those models.