### PR TITLE
Fix "Missing Title" on Selector edit page

### DIFF
--- a/app/Models/Selector.php
+++ b/app/Models/Selector.php
@@ -23,6 +23,10 @@ class Selector extends Model
         'number',
     ];
 
+    protected $casts = [
+        'number' => 'string',
+    ];
+
     protected $appends = [
         'locales',
         'selectable_title',

--- a/tests/Browser/TitleTest.php
+++ b/tests/Browser/TitleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Browser;
 
 use App\Models\Api\Audio as ApiAudio;
 use App\Models\Audio;
+use App\Models\Selector;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
@@ -13,7 +14,7 @@ class TitleTest extends DuskTestCase
 {
     use DatabaseTruncation;
 
-    public function test_title_is_always_displayed(): void
+    public function test_title_is_always_displayed_for_augmented_models(): void
     {
         $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
         $apiAudio = ApiAudio::query()->limit(1)->get()->first();
@@ -30,6 +31,19 @@ class TitleTest extends DuskTestCase
                 ->assertDontSeeIn('.titleEditor h2', 'Missing Title')
                 ->assertSeeIn('.titleEditor h2', $apiAudio->title)
                 ->screenshot("$test 2 - API Audio Title");
+        });
+    }
+
+    public function test_title_is_always_displayed_for_models_with_numeric_titles(): void
+    {
+        $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
+        $this->browse(function (Browser $browser) use ($test) {
+            $selector = Selector::factory()->create();
+            $browser->loginAs($this->user(), 'twill_users')
+                ->visit("/admin/selectors/$selector->id/edit")
+                ->assertDontSeeIn('.titleEditor h2', 'Missing Title')
+                ->assertSeeIn('.titleEditor h2', $selector->number)
+                ->screenshot("$test 1 - Selector Title");
         });
     }
 }


### PR DESCRIPTION
The title editor component was getting confused because the title was of type `number` instead of `string`.