### PR TITLE
Add `active` field to Floor's translated attributes

### DIFF
--- a/app/Models/Floor.php
+++ b/app/Models/Floor.php
@@ -43,6 +43,7 @@ class Floor extends Model
     ];
 
     public $translatedAttributes = [
+        'active',
         'title',
     ];
 


### PR DESCRIPTION
This fixes the issue that Josh noted here: https://art-institute-of-chicago.atlassian.net/browse/MA-119?focusedCommentId=19851