### PR TITLE
Add featured tours to JSON

### DIFF
--- a/app/Models/Transformers/FeaturedTourTransformer.php
+++ b/app/Models/Transformers/FeaturedTourTransformer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models\Transformers;
+
+use A17\Twill\Models\Contracts\TwillModelContract;
+use League\Fractal\TransformerAbstract;
+
+class FeaturedTourTransformer extends TransformerAbstract
+{
+    public function transform(TwillModelContract $tour)
+    {
+        return [
+            (string) $tour->id,
+        ];
+    }
+}

--- a/app/Repositories/Serializers/DashboardSerializer.php
+++ b/app/Repositories/Serializers/DashboardSerializer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Repositories\Serializers;
+
+/**
+ * Due to legacy constraints, the dashboard serializer is essentially a wrapper
+ * around the featured tour serializer with an additional unused
+ * `featured_exhibitions` key.
+ */
+class DashboardSerializer
+{
+    public function serialize($featuredTours)
+    {
+        $featuredTourSerializer = new FeaturedTourSerializer();
+        return [
+            'dashboard' =>
+                array_merge(
+                    $featuredTourSerializer->serialize($featuredTours),
+                    ['featured_exhibitions' => []],  // Legacy from Drupal
+                )
+        ];
+    }
+}

--- a/app/Repositories/Serializers/FeaturedTourSerializer.php
+++ b/app/Repositories/Serializers/FeaturedTourSerializer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Repositories\Serializers;
+
+use App\Models\Transformers\FeaturedTourTransformer;
+use League\Fractal\Manager;
+use League\Fractal\Resource;
+
+class FeaturedTourSerializer
+{
+    protected ?Manager $manager = null;
+
+    public function __construct()
+    {
+        $this->manager = new Manager();
+        $this->manager->setSerializer(new FlatArraySerializer());
+    }
+
+    public function serialize($tours)
+    {
+        $tours = collect($tours)->sortBy('position');
+        $resource = new Resource\Collection($tours, new FeaturedTourTransformer(), 'featured_tours');
+        return $this->manager->createData($resource)->toArray();
+    }
+}

--- a/app/Repositories/Serializers/FlatArraySerializer.php
+++ b/app/Repositories/Serializers/FlatArraySerializer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Repositories\Serializers;
+
+use League\Fractal\Serializer\ArraySerializer;
+
+class FlatArraySerializer extends ArraySerializer
+{
+    public function collection($resourceKey, array $data): array
+    {
+        return [$resourceKey => collect($data)->flatten()];
+    }
+}

--- a/database/factories/TourFactory.php
+++ b/database/factories/TourFactory.php
@@ -10,12 +10,13 @@ class TourFactory extends Factory
     {
         return [
             'active' => true, // Simulates an active translation
-            'title' => fake()->words(5, asText: true),
             'description' => fake()->words(100, asText: true),
-            'intro' => fake()->words(100, asText: true),
             'duration' => fake()->numberBetween(10, 60),
+            'featured' => fake()->boolean(),
+            'intro' => fake()->words(100, asText: true),
             'position' => fake()->unique()->numberBetween(0, 20),
             'published' => fake()->boolean(),
+            'title' => fake()->words(5, asText: true),
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,10 +4,11 @@ use App\Repositories\Api\CollectionObjectRepository;
 use App\Repositories\Api\GalleryRepository;
 use App\Repositories\Api\SoundRepository;
 use App\Repositories\Serializers\AudioSerializer;
-use App\Repositories\TourRepository;
+use App\Repositories\Serializers\DashboardSerializer;
 use App\Repositories\Serializers\GallerySerializer;
 use App\Repositories\Serializers\ObjectSerializer;
 use App\Repositories\Serializers\TourSerializer;
+use App\Repositories\TourRepository;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
@@ -31,6 +32,13 @@ Route::get('/audio_files', function () {
     $audios = $repository->getBaseModel()->newQuery()->get();
     $serializer = new AudioSerializer();
     return $serializer->serialize($audios);
+});
+
+Route::get('/dashboard', function () {
+    $tourRepository = App::make(TourRepository::class);
+    $featuredTours = $tourRepository->getBaseModel()->newQuery()->visible()->published()->featured()->select('id')->get();
+    $dashboardSerializer = new DashboardSerializer();
+    return $dashboardSerializer->serialize($featuredTours);
 });
 
 Route::get('/galleries', function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,7 +36,7 @@ Route::get('/audio_files', function () {
 
 Route::get('/dashboard', function () {
     $tourRepository = App::make(TourRepository::class);
-    $featuredTours = $tourRepository->getBaseModel()->newQuery()->visible()->published()->featured()->select('id')->get();
+    $featuredTours = $tourRepository->getBaseModel()->newQuery()->visible()->published()->featured()->get();
     $dashboardSerializer = new DashboardSerializer();
     return $dashboardSerializer->serialize($featuredTours);
 });

--- a/tests/Feature/DashboardSerializerTest.php
+++ b/tests/Feature/DashboardSerializerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tour;
+use App\Repositories\Serializers\DashboardSerializer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardSerializerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_serialize(): void
+    {
+        $serializer = new DashboardSerializer();
+        $featuredTours = Tour::factory(['featured' => true])->count(2)->create();
+        $serialized = $serializer->serialize($featuredTours);
+
+        $this->assertArrayHasKey('dashboard', $serialized);
+        $this->assertArrayHasKey('featured_tours', $serialized['dashboard']);
+        $this->assertNotEmpty($serialized['dashboard']['featured_tours']);
+        $this->assertArrayHasKey('featured_exhibitions', $serialized['dashboard']);
+        $this->assertEmpty($serialized['dashboard']['featured_exhibitions']);
+    }
+}

--- a/tests/Feature/FeaturedTourSerializerTest.php
+++ b/tests/Feature/FeaturedTourSerializerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tour;
+use App\Repositories\Serializers\FeaturedTourSerializer;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FeaturedTourSerializerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_serialize(): void
+    {
+        $serializer = new FeaturedTourSerializer();
+        Tour::factory()->count(3)->sequence(['featured' => true], ['featured' => false])->create();
+        $featuredTours = Tour::featured()->get();
+        $serialized = $serializer->serialize($featuredTours);
+
+        $this->assertArrayHasKey('featured_tours', $serialized);
+        $this->assertCount($featuredTours->count(), $serialized['featured_tours']);
+        foreach ($serialized['featured_tours'] as $id) {
+            $this->assertIsString($id);
+            $this->assertContains((int) $id, $featuredTours->pluck('id'));
+        }
+    }
+}

--- a/tests/Unit/FlatArraySerializerTest.php
+++ b/tests/Unit/FlatArraySerializerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Repositories\Serializers\FlatArraySerializer;
+use PHPUnit\Framework\TestCase;
+
+class FlatArraySerializerTest extends TestCase
+{
+    public function test_collection_returns_a_flattened_array(): void
+    {
+        $data = [
+            [
+                [
+                    '123',
+                ],
+            ],
+            [
+                [
+                    '456',
+                ],
+            ],
+            [
+                [
+                    '789',
+                ],
+            ],
+        ];
+        $serializer = new FlatArraySerializer();
+        $collection = $serializer->collection('test', $data);
+        $this->assertArrayHasKey('test', $collection, 'The collection is serialized with the correct key');
+        foreach ($data as $datum) {
+            foreach ($datum as $record) {
+                $id = current($record);
+                $this->assertContains(
+                    $id,
+                    $collection['test'],
+                    'The serialized collection is flattened array of ids',
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds featured tours to the JSON output (under the `dashboard` key).

We had determined a while back that [the mobile app doesn't actually use any of the exhibitions data in the JSON file](https://art-institute-of-chicago.atlassian.net/browse/MA-105?focusedCommentId=19523), and instead gets it straight from the API, so that's why the `featured_exhibitions` is always empty.