### PR TITLE
Add patch to allow for updating morph browsers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
             "package": {
                 "type": "metapackage",
                 "name": "vendor/package-patches",
-                "version": "0.0.1",
+                "version": "0.0.2",
                 "require": {
                     "netresearch/composer-patches-plugin": "~1.2"
                 },
@@ -24,6 +24,10 @@
                             {
                                 "title": "MA-129: Add limited formatting to CMS fields",
                                 "url": "patches/MA-129---add-limited-formatting-to-cms-fields.diff"
+                            },
+                            {
+                                "title": "MA-150: Allow updateBrowser() to handle morphOne relationships",
+                                "url": "patches/MA-150---allow-update-browser-morphs.diff"
                             }
                         ]
                     }
@@ -41,7 +45,7 @@
         "laravel/tinker": "^2.8",
         "league/fractal": "^0.16.0",
         "michelf/php-smartypants": "^1.8",
-        "vendor/package-patches": "0.0.1"
+        "vendor/package-patches": "0.0.2"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
@@ -95,6 +99,9 @@
     },
     "config": {
         "optimize-autoloader": true,
+        "platform": {
+            "php": "8.1"
+        },
         "preferred-install": "dist",
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a70a7baeb59bb1949fcc0013fb6cae9",
+    "content-hash": "e199cc8c27df6214425ee6adc94b9476",
     "packages": [
         {
             "name": "aic/data-hub-foundation",
@@ -9098,7 +9098,7 @@
         },
         {
             "name": "vendor/package-patches",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "require": {
                 "netresearch/composer-patches-plugin": "~1.2"
             },
@@ -9109,6 +9109,10 @@
                         {
                             "title": "MA-129: Add limited formatting to CMS fields",
                             "url": "patches/MA-129---add-limited-formatting-to-cms-fields.diff"
+                        },
+                        {
+                            "title": "MA-150: Allow updateBrowser() to handle morphOne relationships",
+                            "url": "patches/MA-150---allow-update-browser-morphs.diff"
                         }
                     ]
                 }
@@ -11836,5 +11840,8 @@
         "php": "^8.1"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/patches/MA-150---allow-update-browser-morphs.diff
+++ b/patches/MA-150---allow-update-browser-morphs.diff
@@ -1,0 +1,26 @@
+diff --git a/src/Repositories/Behaviors/HandleBrowsers.php b/src/Repositories/Behaviors/HandleBrowsers.php
+index c84fbbbf..4ffecd79 100644
+--- a/src/Repositories/Behaviors/HandleBrowsers.php
++++ b/src/Repositories/Behaviors/HandleBrowsers.php
+@@ -5,8 +5,7 @@ namespace A17\Twill\Repositories\Behaviors;
+ use A17\Twill\Models\Behaviors\HasMedias;
+ use Illuminate\Database\Eloquent\Model as EloquentModel;
+ use Illuminate\Database\Eloquent\Relations\BelongsTo;
+-use Illuminate\Database\Eloquent\Relations\HasMany;
+-use Illuminate\Database\Eloquent\Relations\HasOne;
++use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+ use Illuminate\Database\Eloquent\Relations\MorphTo;
+ use Illuminate\Support\Arr;
+ use Illuminate\Support\Str;
+@@ -119,10 +118,7 @@ trait HandleBrowsers
+             }
+
+             $object->save();
+-        } elseif (
+-            $object->$relationship() instanceof HasOne ||
+-            $object->$relationship() instanceof HasMany
+-        ) {
++        } elseif ($object->$relationship() instanceof HasOneOrMany) {
+             $this->updateBelongsToInverseBrowser($object, $relationship, $relatedElements);
+         } else {
+             $object->$relationship()->sync($relatedElementsWithPosition);


### PR DESCRIPTION
Twill's `HandleBrowsers::updateBrowser()` method was accounting for `HasOne` and `HasMany` relationships, but not `MorphOne` or `MorphMany`. But all of those classes derive from `HasOneOrHasMany`.