### PR TITLE
Simplify Audios relationship to Selectors

### DIFF
--- a/app/Http/Controllers/Twill/AudioController.php
+++ b/app/Http/Controllers/Twill/AudioController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers\Twill;
 
-use Illuminate\Support\Facades\Session;
-use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Forms\BladePartial;
 use A17\Twill\Services\Forms\Fields\Input;
 use A17\Twill\Services\Forms\Fields\Radios;
@@ -13,8 +11,6 @@ use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Text;
 use A17\Twill\Services\Listings\TableColumns;
 use App\Http\Controllers\Twill\Columns\ApiRelation;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Str;
 
 class AudioController extends BaseApiController
 {
@@ -115,53 +111,6 @@ class AudioController extends BaseApiController
                             ->view('admin.fields.audio')
                             ->withAdditionalParams(['src' => $audio->getApiModel()->content]),
                     ])
-            )
-            ->addFieldset(
-                Fieldset::make()
-                    ->id('audio_actions')
-                    ->title('Actions')
-                    ->fields($this->actions($audio))
             );
-    }
-
-    /**
-     * If the update is successful, respond with a self-redirect to induce a
-     * page layout refresh.
-     */
-    public function update(int|TwillModelContract $id, ?int $submoduleId = null): JsonResponse
-    {
-        $response = parent::update($id, $submoduleId);
-        if ($response->getStatusCode() == 200) {
-            Session::put($this->moduleName . '_retain', false);
-            return $this->respondWithRedirect(
-                moduleRoute($this->moduleName, $this->routePrefix, 'edit', [Str::singular($this->moduleName) => $id])
-            );
-        }
-        return $response;
-    }
-
-    protected function actions($audio): array
-    {
-        if ($audio->selector && !$audio->selector->selectable) {
-            return [
-                BladePartial::make()
-                    ->view('admin.fields.action')
-                    ->withAdditionalParams([
-                        'action' => 'Create Stop with Audio',
-                        'href' => route('twill.stops.createWithAudio', parameters: [
-                            'sound_id' => $audio->id,
-                        ]),
-                    ]),
-                BladePartial::make()
-                    ->view('admin.fields.action')
-                    ->withAdditionalParams([
-                        'action' => 'Create Tour with Intro Audio',
-                        'href' => route('twill.tours.createWithAudio', parameters: [
-                            'sound_id' => $audio->id,
-                        ]),
-                    ]),
-            ];
-        }
-        return [];
     }
 }

--- a/app/Http/Controllers/Twill/CollectionObjectController.php
+++ b/app/Http/Controllers/Twill/CollectionObjectController.php
@@ -101,7 +101,7 @@ class CollectionObjectController extends BaseApiController
     {
         if (array_key_exists('selector_id', $scopes)) {
             $selector = \App\Models\Selector::find($scopes['selector_id']);
-            $soundIds = $selector->audio->pluck('datahub_id');
+            $soundIds = $selector->apiAudio->pluck('datahub_id');
             $results = CollectionObject::query()->bySoundIds($soundIds)->get();
             if ($results->isNotEmpty()) {
                 return $results;

--- a/app/Http/Controllers/Twill/SelectorController.php
+++ b/app/Http/Controllers/Twill/SelectorController.php
@@ -9,7 +9,6 @@ use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Relation;
 use A17\Twill\Services\Listings\Columns\Text;
 use A17\Twill\Services\Listings\TableColumns;
-use App\Http\Controllers\Twill\Columns\ApiRelation;
 
 class SelectorController extends BaseController
 {
@@ -43,10 +42,8 @@ class SelectorController extends BaseController
             )
             ->add(
                 Text::make()
-                    ->field('locales')
-                    ->title('Languages')
-                    ->optional()
-                    ->hide()
+                    ->field('audio_title')
+                    ->title('Audio')
             )
             ->add(
                 Text::make()
@@ -56,12 +53,24 @@ class SelectorController extends BaseController
             );
     }
 
+    protected function additionalBrowserTableColumns(): TableColumns
+    {
+        return parent::additionalBrowserTableColumns()
+            ->add(
+                Relation::make()
+                    ->field('title')
+                    ->relation('selectable')
+                    ->sortable()
+            );
+    }
+
     protected function additionalFormFields(TwillModelContract $selector): Form
     {
         return parent::additionalFormFields($selector)
             ->add(
                 Browser::make()
-                    ->name('audio')
+                    ->name('apiAudios')
+                    ->label('Audio')
                     ->modules([\App\Models\Api\Audio::class])
                     ->max(count(getLocales()))
                     ->sortable(false)

--- a/app/Models/Audio.php
+++ b/app/Models/Audio.php
@@ -25,6 +25,7 @@ class Audio extends AbstractModel
         'content',
         'locale',
         'transcript',
+        'selector_id',
     ];
 
     protected $appends = [

--- a/app/Models/Selector.php
+++ b/app/Models/Selector.php
@@ -8,9 +8,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Query\JoinClause;
 
 class Selector extends Model

--- a/app/Models/Selector.php
+++ b/app/Models/Selector.php
@@ -9,9 +9,9 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Query\JoinClause;
-use Illuminate\Support\Facades\DB;
 
 class Selector extends Model
 {
@@ -30,14 +30,16 @@ class Selector extends Model
     ];
 
     protected $appends = [
+        'audio_title',
+        'default_audio',
         'object_datahub_id',
         'object_title',
         'tour_title',
     ];
 
-    public function apiRelatables(): MorphMany
+    public function apiAudios(): MorphToMany
     {
-        return $this->morphMany(ApiRelatable::class, 'api_relatable');
+        return $this->apiElements()->where('relation', 'apiAudios');
     }
 
     public function object(): BelongsTo|MorphTo
@@ -52,6 +54,20 @@ class Selector extends Model
     public function selectable(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    public function audios(): Attribute
+    {
+        return Attribute::make(
+            get: fn() =>  $this->apiAudios?->map(fn ($audio) => Audio::firstWhere('datahub_id', $audio->datahub_id)),
+        );
+    }
+
+    public function defaultAudio(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): ?Audio => $this->audios?->firstWhere('locale', config('app.locale')),
+        );
     }
 
     public function number(): Attribute
@@ -69,6 +85,13 @@ class Selector extends Model
     {
         return Attribute::make(
             get: fn (): string => $this->number,
+        );
+    }
+
+    public function audioTitle(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): string => (string) $this->default_audio?->title,
         );
     }
 
@@ -107,25 +130,6 @@ class Selector extends Model
         );
     }
 
-    public function scopeOrderBySelectableTitle(Builder $query, string $direction = 'asc'): Builder
-    {
-        return $query
-            ->select(
-                'selectors.*',
-                DB::raw('COALESCE(stop_translations.title, tour_translations.title) as selectable_title'),
-            )
-            ->leftJoin('stop_translations', function (JoinClause $join) {
-                $join->on('selectors.selectable_id', '=', 'stop_translations.stop_id')
-                    ->where('selectors.selectable_type', '=', 'stop')
-                    ->where('stop_translations.locale', '=', config('app.locale'));
-            })
-            ->leftJoin('tour_translations', function (JoinClause $join) {
-                $join->on('selectors.selectable_id', '=', 'tour_translations.tour_id')
-                    ->where('selectors.selectable_type', '=', 'tour')
-                    ->where('tour_translations.locale', '=', config('app.locale'));
-            })
-            ->orderBy('selectable_title', $direction);
-    }
 
     public function scopeOrderByTourTitle(Builder $query, string $direction = 'asc'): Builder
     {

--- a/app/Repositories/AudioRepository.php
+++ b/app/Repositories/AudioRepository.php
@@ -36,7 +36,7 @@ class AudioRepository extends BaseApiRepository
                 $audio->apiRelation?->morph()->delete();
                 // We don't care about `position` for the selector / audio
                 // relationship, so give it an arbitrary one.
-                $selector->audio()->attach($apiRelation, ['relation' => 'audio', 'position' => 0]);
+                $selector->apiAudios()->attach($apiRelation, ['relation' => 'audio', 'position' => 0]);
             }
         }
         parent::afterSave($audio, $fields);

--- a/app/Repositories/SelectorRepository.php
+++ b/app/Repositories/SelectorRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories;
 
+use App\Models\Audio;
 use App\Models\CollectionObject;
 use App\Models\Selector;
 use App\Repositories\ModuleRepository;
@@ -11,7 +12,7 @@ use Illuminate\Support\Str;
 class SelectorRepository extends ModuleRepository
 {
     protected $apiBrowsers = [
-        'audio' => [
+        'apiAudios' => [
             'moduleName' => 'audio',
             'isApiRelation' => true,
         ]
@@ -28,10 +29,6 @@ class SelectorRepository extends ModuleRepository
         $orderBy['number'] ??= 'asc';
         unset($orderBy['created_at']);
 
-        if (array_key_exists('selectable_title', $orderBy)) {
-            $query->orderBySelectableTitle($orderBy['selectable_title']);
-            unset($orderBy['selectable_title']);
-        }
         if (array_key_exists('tour_title', $orderBy)) {
             $query->orderByTourTitle($orderBy['tour_title']);
             unset($orderBy['tour_title']);
@@ -51,6 +48,7 @@ class SelectorRepository extends ModuleRepository
     {
         $this->updateObjectBrowser($selector, $fields);
         $this->updateSelectableBrowser($selector, $fields);
+        $this->updateAudioBrowser($selector, $fields);
         parent::afterSave($selector, $fields);
     }
 
@@ -118,5 +116,18 @@ class SelectorRepository extends ModuleRepository
             $selector->selectable()->dissociate();
         }
         $selector->save();
+    }
+
+    protected function updateAudioBrowser($selector, $fields)
+    {
+        if (isset($fields['browsers']['apiAudios'])) {
+            foreach ($fields['browsers']['apiAudios'] as $audio) {
+                $audio = Audio::firstOrCreate([
+                    'datahub_id' => $audio['id'],
+                    'selector_id' => $selector->id,
+                ]);
+                $audio->save();
+            }
+        }
     }
 }

--- a/database/migrations/2023_12_01_191229_add_selector_relation_to_audios.php
+++ b/database/migrations/2023_12_01_191229_add_selector_relation_to_audios.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('audios', function (Blueprint $table) {
+            $table->string('datahub_id')->nullable()->change();
+            $table->foreignId('selector_id')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('audios', function (Blueprint $table) {
+            $table->string('datahub_id')->nullable(false)->change();
+            $table->dropColumn(['selector_id']);
+        });
+    }
+};

--- a/tests/Browser/SelectorTest.php
+++ b/tests/Browser/SelectorTest.php
@@ -36,7 +36,6 @@ class SelectorTest extends DuskTestCase
 
     public function test_user_can_add_audio_to_selector(): void
     {
-        $this->markTestSkipped('Temporarily skipped');
         $test = Str::of(__FUNCTION__)->title()->replace('_', ' ');
         $selector = Selector::factory()->create();
         $audio = Audio::query()->limit(1)->get()->first();


### PR DESCRIPTION
This adds a reference from an augmented audio back to the selector (instead of solely relying on the convoluted api_relations, api_relatables, and api audio relationships) and creates/updates that reference when an audio is added or removed.