### PR TITLE
Reduce page load times for api models

### DIFF
--- a/app/Http/Controllers/Twill/BaseApiController.php
+++ b/app/Http/Controllers/Twill/BaseApiController.php
@@ -43,6 +43,7 @@ class BaseApiController extends ModuleController
     protected function setUpController(): void
     {
         $this->setFeatureField('is_featured');
+        $this->setResultsPerPage(5);
 
         $this->disableBulkDelete();
         $this->disableBulkEdit();


### PR DESCRIPTION
...by retrieving fewer records per page.

The slowness is especially noticeable when deployed to `testing`.