### PR TITLE
Make overriding "Is On View" clearer [MA-161]

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -4,9 +4,11 @@ APP_KEY=base64:mtTLixAtmR5vwu2J/GB1+NHqqopjFNFE1pJhZ47dyLg=
 APP_DEBUG=true
 APP_URL='http://localhost'
 
+API_BASE_URI=https://api.artic.edu
+
 DB_CONNECTION='mysql'
 DB_HOST='127.0.0.1'
 DB_PORT=3306
 DB_DATABASE='mobile-admin-test'
-DB_USERNAME='mobile-admin'
+DB_USERNAME='homestead'
 DB_PASSWORD='secret'

--- a/app/Http/Controllers/Twill/CollectionObjectController.php
+++ b/app/Http/Controllers/Twill/CollectionObjectController.php
@@ -7,6 +7,7 @@ use A17\Twill\Services\Forms\Fields\Browser;
 use A17\Twill\Services\Forms\Fields\Checkbox;
 use A17\Twill\Services\Forms\Fields\Input;
 use A17\Twill\Services\Forms\Fields\Medias;
+use A17\Twill\Services\Forms\Columns;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Boolean;
 use A17\Twill\Services\Listings\Columns\Text;
@@ -46,13 +47,21 @@ class CollectionObjectController extends BaseApiController
             ->add(Text::make()
                 ->field('artist_display'))
             ->add(Boolean::make()
-                ->field('is_on_view'))
-            ->add(
-                ApiRelation::make()
-                    ->field('title')
-                    ->title('Gallery')
-                    ->relation('gallery')
-            )
+                ->field('is_on_view')
+                ->title('Is On View (CITI / Override)')
+                ->customRender(function (CollectionObject $object) {
+                    $object->refreshApi();
+                    $augmentedObject = $object->getAugmentedModel();
+                    $render = $augmentedObject?->getApiField('is_on_view') ? "✅" : "🙈";
+                    if ($augmentedObject?->is_on_view) {
+                        $render .= " / ✅";
+                    }
+                    return $render;
+                }))
+            ->add(ApiRelation::make()
+                ->field('title')
+                ->title('Galleries')
+                ->relation('gallery'))
             ->add(Text::make()
                 ->field('main_reference_number')
                 ->optional()
@@ -138,9 +147,19 @@ class CollectionObjectController extends BaseApiController
                     ->placeholder($apiValues['artist_display'])
             )
             ->add(
-                Checkbox::make()
-                    ->name('is_on_view')
-                    ->default($apiValues['is_on_view'])
+                Columns::make()
+                    ->left([
+                        Input::make()
+                            ->name('citi_on_view_status')
+                            ->label('CITI On View Status 🦁')
+                            ->placeholder($apiValues['is_on_view'] ? '👀 On View' : '🙈 Not On View')
+                            ->disabled()
+                    ])
+                    ->right([
+                        Checkbox::make()
+                            ->name('is_on_view')
+                            ->label('Force On View 📱')
+                    ])
             )
             ->add(
                 Input::make()

--- a/app/Models/Behaviors/HasApiModel.php
+++ b/app/Models/Behaviors/HasApiModel.php
@@ -55,8 +55,8 @@ trait HasApiModel
                 // Something like ['id' => 'datahub_id']
             } else {
                 $this->setAttribute($key, $value);
-                array_push($this->apiFields, $key);
             }
+            array_push($this->apiFields, $key);
         }
     }
 
@@ -67,7 +67,7 @@ trait HasApiModel
 
     public function getApiField($field)
     {
-        return $this->getApiFields[$field];
+        return $this->getApiFields()->{$field} ?? null;
     }
 
     /**
@@ -75,10 +75,6 @@ trait HasApiModel
      */
     public function getApiFields(): object
     {
-        return (object) array_reduce($this->apiFields, function ($result, $field) {
-            $result[$field] = $this->{$field};
-
-            return $result;
-        }, []);
+        return (object) $this->apiModel->toArray();
     }
 }


### PR DESCRIPTION
This change makes it more apparent when an editor has overridden an object's "Is On View" status from CITI.